### PR TITLE
add multi framework model logging with log_model toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+mlruns/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlops_wrapper"
-version = "0.2.0"
+version = "0.3.0"
 description = "a unified mlflow wrapper for standardized ML model logging and registration."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/mlops_wrapper/mlflow_wrapper.py
+++ b/src/mlops_wrapper/mlflow_wrapper.py
@@ -5,6 +5,169 @@ import datetime
 import os
 
 
+def _detect_model_framework(model) -> str:
+    """
+    detect ml framework from model instance
+
+    returns framework name: 'catboost', 'sklearn', 'xgboost', 'lightgbm', 'pytorch', 'tensorflow', or 'unknown'
+    """
+    model_module = type(model).__module__
+    model_class = type(model).__name__
+
+    # check module path for framework identification
+    if 'catboost' in model_module.lower():
+        return 'catboost'
+    elif 'sklearn' in model_module.lower():
+        return 'sklearn'
+    elif 'xgboost' in model_module.lower():
+        return 'xgboost'
+    elif 'lightgbm' in model_module.lower() or 'lgb' in model_module.lower():
+        return 'lightgbm'
+    elif 'torch' in model_module.lower() or 'pytorch' in model_module.lower():
+        return 'pytorch'
+    elif 'tensorflow' in model_module.lower() or 'keras' in model_module.lower():
+        return 'tensorflow'
+
+    return 'unknown'
+
+
+def _create_robust_signature(model_inputs, model_predictions):
+    """
+    create mlflow signature with integer columns converted to double
+
+    prevents schema enforcement errors when integer columns may have missing values
+    at inference time. common for boolean features encoded as integers.
+
+    note: this is an opinionated choice. if your model genuinely uses integer
+    features that should never have missing values, override by providing your
+    own signature in the return dict.
+
+    args:
+        model_inputs: training features (dataframe or array)
+        model_predictions: model predictions for signature output
+
+    returns:
+        mlflow ModelSignature or None if inference fails
+    """
+    try:
+        from mlflow.models.signature import infer_signature
+        from mlflow.types.schema import Schema, ColSpec, DataType
+
+        # infer base signature
+        base_signature = infer_signature(model_inputs, model_predictions)
+
+        # convert integer columns to double to handle missing values
+        if base_signature and base_signature.inputs:
+            updated_inputs = []
+            for col_spec in base_signature.inputs.inputs:
+                if col_spec.type in [DataType.integer, DataType.long]:
+                    updated_inputs.append(ColSpec(type=DataType.double, name=col_spec.name))
+                else:
+                    updated_inputs.append(col_spec)
+
+            return mlflow.models.signature.ModelSignature(
+                inputs=Schema(updated_inputs),
+                outputs=base_signature.outputs
+            )
+
+        return base_signature
+
+    except Exception as e:
+        print(f"  warning: signature inference failed: {e}")
+        return None
+
+
+def _log_model_by_framework(
+    model,
+    artifact_path: str = 'model',
+    signature=None,
+    input_example=None,
+    model_inputs=None,
+    model_predictions=None,
+    **kwargs
+):
+    """
+    log model using framework-specific mlflow logging function
+
+    automatically detects framework and uses appropriate mlflow.<framework>.log_model()
+    falls back to mlflow.pyfunc for unknown frameworks
+
+    args:
+        model: trained model instance
+        artifact_path: path within run artifacts (default: 'model') - uses 'name' param internally
+        signature: mlflow model signature (optional - auto-generated if model_inputs provided)
+        input_example: sample input for inference testing (optional - auto-generated from model_inputs)
+        model_inputs: training inputs for auto-generating signature (optional)
+        model_predictions: training predictions for auto-generating signature (optional)
+        **kwargs: additional arguments passed to framework log_model function
+
+    raises:
+        exception if model logging fails
+    """
+    framework = _detect_model_framework(model)
+
+    print(f"logging model (framework: {framework}, path: {artifact_path})")
+
+    # auto-generate signature if not provided but inputs available
+    if signature is None and model_inputs is not None and model_predictions is not None:
+        signature = _create_robust_signature(model_inputs, model_predictions)
+
+    # auto-generate input_example if not provided but inputs available
+    if input_example is None and model_inputs is not None:
+        try:
+            import pandas as pd
+            if isinstance(model_inputs, pd.DataFrame):
+                input_example = model_inputs.head(1)
+            elif hasattr(model_inputs, '__getitem__'):
+                input_example = model_inputs[:1]
+        except Exception as e:
+            print(f"  info: input_example generation failed: {e}")
+            pass
+
+    # use 'name' instead of deprecated 'artifact_path'
+    model_kwargs = {'name': artifact_path, 'signature': signature, 'input_example': input_example, **kwargs}
+
+    try:
+        if framework == 'catboost':
+            import mlflow.catboost
+            mlflow.catboost.log_model(cb_model=model, **model_kwargs)
+        elif framework == 'sklearn':
+            import mlflow.sklearn
+            mlflow.sklearn.log_model(sk_model=model, **model_kwargs)
+        elif framework == 'xgboost':
+            import mlflow.xgboost
+            mlflow.xgboost.log_model(xgb_model=model, **model_kwargs)
+        elif framework == 'lightgbm':
+            import mlflow.lightgbm
+            mlflow.lightgbm.log_model(lgb_model=model, **model_kwargs)
+        elif framework == 'pytorch':
+            import mlflow.pytorch
+            mlflow.pytorch.log_model(pytorch_model=model, **model_kwargs)
+        elif framework == 'tensorflow':
+            import mlflow.tensorflow
+            mlflow.tensorflow.log_model(model=model, **model_kwargs)
+        else:
+            # fallback to pyfunc for unknown frameworks
+            print(f"  warning: unknown framework '{framework}', using mlflow.pyfunc")
+            import mlflow.pyfunc
+            mlflow.pyfunc.log_model(python_model=model, **model_kwargs)
+
+        print(f"  ✓ model logged successfully")
+
+        # tag framework for later reference
+        mlflow.set_tag('mlops.model_framework', framework)
+
+        # warn if signature/input_example missing (best practice)
+        if signature is None:
+            print("  info: consider adding 'signature' for better model serving")
+        if input_example is None:
+            print("  info: consider adding 'input_example' for inference validation")
+
+    except Exception as e:
+        print(f"  ✗ model logging failed: {e}")
+        raise
+
+
 class MLflowWrapper:
     def __init__(
         self,
@@ -125,19 +288,40 @@ def mlflow_experiment(
     tracking_uri: str = None,
     autolog_enabled: bool = True,
     autolog_config: dict = None,
+    log_model: bool = True,
 ):
     """
     decorator for wrapping training functions. it ensures:
     - the mlflow run is started with standardized naming.
-    - logs parameters, metrics, and artifacts from the function's return.
+    - logs parameters, metrics, models, and artifacts from the function's return.
+    - handles framework-specific model logging (catboost, sklearn, xgboost, lightgbm, pytorch, tensorflow).
     - catches exceptions and logs them.
 
+    args:
+        experiment_name: name of the mlflow experiment
+        run_name: optional name for the run
+        tags: optional dict of tags to add to the run
+        tracking_uri: mlflow tracking server uri
+        autolog_enabled: enable mlflow autolog for supported frameworks
+        autolog_config: optional config dict for autolog
+        log_model: if True, logs model artifact to run. set False for local
+                   development runs to save storage and time. default: True.
+
     the wrapped function should return a dictionary with keys:
-        - 'params': dict of hyperparameters
-        - 'metrics': dict of evaluation metrics
-        - optional 'artifacts': path to artifacts (can be a file or directory)
-        - optional 'model_local_path': path to the saved model for registration
-        - optional 'model_name': model registry name for automatic registration
+        - 'params': dict of hyperparameters (required if autolog fails)
+        - 'metrics': dict of evaluation metrics (required if autolog fails)
+        - optional 'model': trained model instance (recommended - enables automatic framework-specific logging)
+        - optional 'signature': mlflow model signature (recommended for model serving)
+        - optional 'input_example': sample input data (recommended for inference validation)
+        - optional 'artifact_path': custom path for model artifact (default: 'model')
+        - optional 'artifacts': path to additional artifacts directory
+        - optional 'model_local_path': path to pre-logged model for registration (legacy)
+        - optional 'model_name': model registry name for automatic registration (legacy)
+
+    note: if you return 'model', the wrapper automatically:
+        - detects the framework (catboost, sklearn, xgboost, etc.)
+        - logs using appropriate mlflow.<framework>.log_model()
+        - handles cases where autolog doesn't work (e.g., catboost)
     """
 
     def decorator(func):
@@ -164,7 +348,9 @@ def mlflow_experiment(
                 # detect autolog failure (when enabled but captured nothing)
                 if autolog_enabled and len(autolog_params) == 0:
                     print("warning: autolog enabled but captured 0 params")
-                    print("  framework may not support autolog (e.g., catboost)")
+                    print("  this typically means:")
+                    print("    - framework has no autolog support (e.g., catboost)")
+                    print("    - model was not trained within the mlflow run context")
                     print("  falling back to manual param logging")
 
                     # require params in return dict
@@ -197,6 +383,23 @@ def mlflow_experiment(
                     mlflow_wrapper.log_params(custom_params)
                 if custom_metrics:
                     mlflow_wrapper.log_metrics(custom_metrics)
+
+                # handle model logging (framework-agnostic)
+                if 'model' in result and log_model:
+                    try:
+                        _log_model_by_framework(
+                            model=result['model'],
+                            artifact_path=result.get('artifact_path', 'model'),
+                            signature=result.get('signature'),
+                            input_example=result.get('input_example'),
+                            model_inputs=result.get('model_inputs'),
+                            model_predictions=result.get('model_predictions')
+                        )
+                        mlflow.set_tag('mlops.model_logged_via', 'explicit')
+                    except Exception as model_log_error:
+                        # if model logging fails, warn but don't fail the whole run
+                        print(f"warning: model logging failed: {model_log_error}")
+                        mlflow.set_tag('mlops.model_log_error', str(model_log_error)[:250])
 
                 if "artifacts" in result:
                     mlflow_wrapper.log_artifacts(result["artifacts"])


### PR DESCRIPTION
- add _detect_model_framework() for catboost, sklearn, xgboost, lightgbm, pytorch, tensorflow
- add _log_model_by_framework() with automatic signature and input_example
- add _create_robust_signature() with int-to-double conversion for boolean features
- integrate model logging in mlflow_experiment decorator
- add log_model parameter to control model artifact logging (default: True)
- fix autolog failure message (remove false xgboost/lightgbm warnings)
- add mlruns/ to .gitignore
- version bump to 0.3.0

tested with:
- catboost: explicit model logging works (no autolog support)
- signature inference with int->double conversion for boolean features
- log_model toggle: false (skip logging) and true (log model) via config/env var